### PR TITLE
Update for use with v5.4.7

### DIFF
--- a/JuceLibraryCode/AppConfig.h
+++ b/JuceLibraryCode/AppConfig.h
@@ -47,7 +47,7 @@
 
 #define JUCE_USE_DARK_SPLASH_SCREEN 0
 
-#define JUCE_PROJUCER_VERSION 0x50406
+#define JUCE_PROJUCER_VERSION 0x50407
 
 //==============================================================================
 #define JUCE_MODULE_AVAILABLE_juce_audio_basics             1
@@ -156,6 +156,10 @@
  //#define JUCE_USE_STUDIO_ONE_COMPATIBLE_PARAMETERS 1
 #endif
 
+#ifndef    JUCE_AU_WRAPPERS_SAVE_PROGRAM_STATES
+ //#define JUCE_AU_WRAPPERS_SAVE_PROGRAM_STATES 0
+#endif
+
 #ifndef    JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE
  //#define JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE 0
 #endif
@@ -236,8 +240,8 @@
 //==============================================================================
 // juce_events flags:
 
-#ifndef    JUCE_EXECUTE_APP_SUSPEND_ON_IOS_BACKGROUND_TASK
- //#define JUCE_EXECUTE_APP_SUSPEND_ON_IOS_BACKGROUND_TASK 0
+#ifndef    JUCE_EXECUTE_APP_SUSPEND_ON_BACKGROUND_TASK
+ //#define JUCE_EXECUTE_APP_SUSPEND_ON_BACKGROUND_TASK 0
 #endif
 
 //==============================================================================

--- a/Source/Settings.h
+++ b/Source/Settings.h
@@ -159,41 +159,41 @@ struct SettingRefs
     SettingRefs (AudioProcessorValueTreeState* parameters)
     {
         // Meta
-        isAdvancedPanelOpen_raw = parameters->getRawParameterValue ("isAdvancedPanelOpen_raw");
-        colorScheme = parameters->getRawParameterValue ("colorScheme");
+        isAdvancedPanelOpen_raw = (float*) parameters->getRawParameterValue ("isAdvancedPanelOpen_raw");
+        colorScheme = (float*) parameters->getRawParameterValue ("colorScheme");
         // Basic
-        osc = parameters->getRawParameterValue ("osc");
-        gain = parameters->getRawParameterValue ("gain");
-        maxPoly = parameters->getRawParameterValue ("maxPoly");
+        osc = (float*) parameters->getRawParameterValue ("osc");
+        gain = (float*) parameters->getRawParameterValue ("gain");
+        maxPoly = (float*) parameters->getRawParameterValue ("maxPoly");
         // ADSR
-        attack = parameters->getRawParameterValue ("attack");
-        decay = parameters->getRawParameterValue ("decay");
-        suslevel = parameters->getRawParameterValue ("suslevel");
-        release = parameters->getRawParameterValue ("release");
+        attack = (float*) parameters->getRawParameterValue ("attack");
+        decay = (float*) parameters->getRawParameterValue ("decay");
+        suslevel = (float*) parameters->getRawParameterValue ("suslevel");
+        release = (float*) parameters->getRawParameterValue ("release");
         // Arpeggio
-        isArpeggioEnabled_raw = parameters->getRawParameterValue ("isArpeggioEnabled_raw");
-        arpeggioTime = parameters->getRawParameterValue ("arpeggioTime");
-        arpeggioDirection = parameters->getRawParameterValue ("arpeggioDirection");
+        isArpeggioEnabled_raw = (float*) parameters->getRawParameterValue ("isArpeggioEnabled_raw");
+        arpeggioTime = (float*) parameters->getRawParameterValue ("arpeggioTime");
+        arpeggioDirection = (float*) parameters->getRawParameterValue ("arpeggioDirection");
         // Bend
-        bendRange = parameters->getRawParameterValue ("bendRange");
+        bendRange = (float*) parameters->getRawParameterValue ("bendRange");
         // Vibrato
-        vibratoRate = parameters->getRawParameterValue ("vibratoRate");
-        vibratoDepth = parameters->getRawParameterValue ("vibratoDepth");
-        vibratoDelay = parameters->getRawParameterValue ("vibratoDelay");
-        vibratoIgnoresWheel_raw = parameters->getRawParameterValue ("vibratoIgnoresWheel_raw");
+        vibratoRate = (float*) parameters->getRawParameterValue ("vibratoRate");
+        vibratoDepth = (float*) parameters->getRawParameterValue ("vibratoDepth");
+        vibratoDelay = (float*) parameters->getRawParameterValue ("vibratoDelay");
+        vibratoIgnoresWheel_raw = (float*) parameters->getRawParameterValue ("vibratoIgnoresWheel_raw");
         // Sweep
-        sweepInitialPitch = parameters->getRawParameterValue ("sweepInitialPitch");
-        sweepTime = parameters->getRawParameterValue ("sweepTime");
+        sweepInitialPitch = (float*) parameters->getRawParameterValue ("sweepInitialPitch");
+        sweepTime = (float*) parameters->getRawParameterValue ("sweepTime");
         // For Pulse
-        duty = parameters->getRawParameterValue ("duty");
+        duty = (float*) parameters->getRawParameterValue ("duty");
         // For Noise
-        noiseAlgorithm_raw = parameters->getRawParameterValue ("noiseAlgorithm_raw");
-        restrictsToNESFrequency_raw = parameters->getRawParameterValue ("restrictsToNESFrequency_raw");
+        noiseAlgorithm_raw = (float*) parameters->getRawParameterValue ("noiseAlgorithm_raw");
+        restrictsToNESFrequency_raw = (float*) parameters->getRawParameterValue ("restrictsToNESFrequency_raw");
         // Sequence
-        isVolumeSequenceEnabled_raw = parameters->getRawParameterValue ("isVolumeSequenceEnabled_raw");
-        isPitchSequenceEnabled_raw = parameters->getRawParameterValue ("isPitchSequenceEnabled_raw");
-        isDutySequenceEnabled_raw = parameters->getRawParameterValue ("isDutySequenceEnabled_raw");
-        pitchSequenceMode_raw = parameters->getRawParameterValue ("pitchSequenceMode_raw");
+        isVolumeSequenceEnabled_raw = (float*) parameters->getRawParameterValue ("isVolumeSequenceEnabled_raw");
+        isPitchSequenceEnabled_raw = (float*) parameters->getRawParameterValue ("isPitchSequenceEnabled_raw");
+        isDutySequenceEnabled_raw = (float*) parameters->getRawParameterValue ("isDutySequenceEnabled_raw");
+        pitchSequenceMode_raw = (float*) parameters->getRawParameterValue ("pitchSequenceMode_raw");
 
     }
 };


### PR DESCRIPTION
Hello, this is related to Issue #1.

According to [this commit](https://github.com/WeAreROLI/JUCE/commit/70ddcd16e60d2dc97f0bdae576528806d71c9090), since the function `getRawParameters` returns a `std::atomic<float>*` in `v5.4.7`, I updated the data types of the values receiving the return values in `Source/Setting.h`

There was one line in `Source/PluginProcessor.cpp` that was affected due to this change, so I changed the code at line 150/151 so it could build.

I've only tested it with my computer, so please let me know if it works.
Also, please let me know if I'm missing anything!

Thank you.