### PR TITLE
Fixed unexpected note sounding when turned on Custom Envelope

### DIFF
--- a/Magical8bitPlug2.jucer
+++ b/Magical8bitPlug2.jucer
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="JWTLbw" name="Magical8bitPlug2" projectType="audioplug" jucerVersion="5.4.6"
-              companyName="YMCK" companyWebsite="http://ymck.net" companyEmail="info@ymck.net"
+<JUCERPROJECT id="JWTLbw" name="Magical8bitPlug2" projectType="audioplug" companyName="YMCK"
+              companyWebsite="http://ymck.net" companyEmail="info@ymck.net"
               pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
               pluginManufacturerCode="Ymck" pluginManufacturer="Ymck" pluginCode="synj"
               pluginChannelConfigs="{0, 2}" pluginAUIsSandboxSafe="1" pluginFormats="buildAU,buildStandalone,buildVST,buildVST3"
               pluginAUMainType="'aumu'" pluginName="Magical 8bit Plug 2" aaxIdentifier="com.ymck.magical8bitPlug2Juce"
               bundleIdentifier="com.ymck.magical8bitPlug2Juce" splashScreenColour="Light"
-              pluginDesc="8bit sound generator 2nd ver. by YMCK">
+              pluginDesc="8bit sound generator 2nd ver. by YMCK" displaySplashScreen="1"
+              jucerFormatVersion="1">
   <MAINGROUP id="tlJ5Jv" name="Magical8bitPlug2">
     <GROUP id="{05934500-901F-8317-27DC-7E17FC00833D}" name="View">
       <GROUP id="{68A7410F-88F9-C9D8-8A37-6A70F269BBCC}" name="BaseComponents">

--- a/Source/BaseVoice.cpp
+++ b/Source/BaseVoice.cpp
@@ -106,6 +106,10 @@ void BaseVoice::stopNote (float, bool allowTailOff)
 
 void BaseVoice::renderNextBlock (AudioSampleBuffer& outputBuffer, int startSample, int numSamples)
 {
+    if (getCurrentlyPlayingNote() == -1) {
+        return;
+    }
+    
     if (angleDelta == 0.0)
     {
         return;


### PR DESCRIPTION
Added another condition to prevent from a voice from sounding unexpectedly.
Specifically, `currentlyPlayingNote` should also have been checked to see if a voice is playing.

fix #12 