### PR TITLE
Initial bend amount wasn't reflected to a starting note

### DIFF
--- a/Source/TonalVoice.cpp
+++ b/Source/TonalVoice.cpp
@@ -22,7 +22,7 @@ void TonalVoice::startNote (int midiNoteNumber, float velocity, SynthesiserSound
 {
     BaseVoice::startNote (midiNoteNumber, velocity, 0, currentPitchBendPosition);
 
-    currentBendAmount = 0;
+    currentBendAmount = * (settingRefs->bendRange) * ((double) (currentPitchBendPosition - 8192)) / 8192.0;
     currentPitchSequenceFrame = 0;
     vibratoCount = 0;
 


### PR DESCRIPTION
Fixed the issue that the bend amount which is already applied before note-on is not applied to a new note

resolves #10 