### PR TITLE
Fixed the behavior when sending a note-off to a note already in release phase

### DIFF
--- a/Source/BaseVoice.cpp
+++ b/Source/BaseVoice.cpp
@@ -89,6 +89,10 @@ void BaseVoice::stopNote (float, bool allowTailOff)
     {
         if (settingRefs->volumeSequence.hasRelease)
         {
+            if (settingRefs->volumeSequence.isInRelease(currentVolumeSequenceFrame)) {
+                // Already in release(Custom Env.)
+                return ;
+            }
             currentVolumeSequenceFrame = settingRefs->volumeSequence.releaseSequenceStartIndex;
             currentEnvelopeLevel = (float) (settingRefs->volumeSequence.valueAt (0)) / 15.0f;
         }
@@ -98,6 +102,11 @@ void BaseVoice::stopNote (float, bool allowTailOff)
             angleDelta = 0.0;
         }
 
+        return;
+    }
+    
+    if (envelopePhase == kEnvelopePhaseR) {
+        // Already in release(ADSR)
         return;
     }
 

--- a/Source/FrameSequence.h
+++ b/Source/FrameSequence.h
@@ -68,4 +68,8 @@ struct FrameSequence
 
         // No reach here
     }
+    
+    bool isInRelease(int index) {
+        return index >= releaseSequenceStartIndex;
+    }
 };


### PR DESCRIPTION
The state of a note was forced to go back to the beginning of Release Phase whenever it receives note-off regardless if it's already in Release Phase or not.
Fixed it by checking if a note is already in Release Phase

resolves #11 