### PR TITLE
Added new parse warning message

### DIFF
--- a/Source/CustomEnvelopeComponent.cpp
+++ b/Source/CustomEnvelopeComponent.cpp
@@ -153,6 +153,10 @@ void CustomEnvelopeComponent::textEditorTextChanged (TextEditor& editor)
 
     ParseError err = kParseErrorNone;
     processor.settingRefs.setSequenceWithString (paramType, txt, &err);
+    
+    ColorScheme cs = ColorScheme (processor.settingRefs.colorSchemeType());
+    Colour c = (err < kParseErrorLevelFatal) ? cs.main : cs.warning;
+    label->setColour (juce::Label::textColourId, c);
 
     if (err == kParseErrorValueOutOfRange)
     {

--- a/Source/EnvelopeParserTest.h
+++ b/Source/EnvelopeParserTest.h
@@ -320,5 +320,35 @@ public:
         FrameSequence result29 = parser.parse(input29, 0, 2, &error);
         expect(error = kParseErrorValueOutOfRange);
 
+        beginTest ("Empty segment warning(pre-repeat)");
+        error = kParseErrorNone;
+        String input30 = "[1]|2";
+        FrameSequence result30 = parser.parse(input30, 0, 2, &error);
+        expect(result30.valueAt(0) == 1);
+        expect(result30.valueAt(1) == 2);
+        expect(result30.loopStartIndex == 0);
+        expect(result30.releaseSequenceStartIndex == 1);
+        expect(error = kParseWarningPreRepeatSegmentEmpty);
+
+        beginTest ("Empty segment warning(in-repeat)");
+        error = kParseErrorNone;
+        String input31 = "1[]|2";
+        FrameSequence result31 = parser.parse(input31, 0, 2, &error);
+        expect(result31.valueAt(0) == 1);
+        expect(result31.valueAt(1) == 2);
+        expect(result31.loopStartIndex == 1);
+        expect(result31.releaseSequenceStartIndex == 1);
+        expect(error = kParseWarningRepeatSegmentEmpty);
+
+        beginTest ("Empty segment warning(after release)");
+        error = kParseErrorNone;
+        String input32 = "1[2]|";
+        FrameSequence result32 = parser.parse(input32, 0, 2, &error);
+        expect(result32.valueAt(0) == 1);
+        expect(result32.valueAt(1) == 2);
+        expect(result32.loopStartIndex == 1);
+        expect(result32.releaseSequenceStartIndex == 2);
+        expect(error = kParseWarningReleaseSegmentEmpty);
+
     }
 };

--- a/Source/FrameSequenceParseErrors.cpp
+++ b/Source/FrameSequenceParseErrors.cpp
@@ -14,6 +14,18 @@ String getParseErrorString (ParseError err, int minValue, int maxValue)
 {
     switch (err)
     {
+        case kParseWarningPreRepeatSegmentEmpty:
+            return TRANS ("Main body of the sequence is empty");
+            break;
+
+        case kParseWarningRepeatSegmentEmpty:
+            return TRANS ("Repeat section is empty");
+            break;
+
+        case kParseWarningReleaseSegmentEmpty:
+            return TRANS ("Release section is empty");
+            break;
+
         case kParseErrorDuplicatedReleaseDelimiter:
             return TRANS ("You cannot use \"|\" more than once");
             break;

--- a/Source/FrameSequenceParseErrors.h
+++ b/Source/FrameSequenceParseErrors.h
@@ -15,6 +15,9 @@ enum ParseError
 {
     kParseErrorNone = 0,
     kParseErrorLevelWarning,
+    kParseWarningPreRepeatSegmentEmpty,
+    kParseWarningRepeatSegmentEmpty,
+    kParseWarningReleaseSegmentEmpty,
     kParseErrorLevelFatal,
     kParseErrorDuplicatedReleaseDelimiter,
     kParseErrorDuplicatedOpenBracket,

--- a/Source/FrameSequenceParser.cpp
+++ b/Source/FrameSequenceParser.cpp
@@ -438,6 +438,9 @@ FrameSequence FrameSequenceParser::parse (const String& input,
     {
         return fs;
     }
+    if (sequence.size() == 0) {
+        *error = kParseWarningPreRepeatSegmentEmpty;
+    }
 
     fs.sequence = sequence;
     fs.sequence.reserve (1000);
@@ -455,6 +458,10 @@ FrameSequence FrameSequenceParser::parse (const String& input,
         if (*error > kParseErrorLevelFatal)
         {
             return fs;
+        }
+        if (repeatSeq.size() == 0) {
+            // Repeat section is defined but content is empty
+            *error = kParseWarningRepeatSegmentEmpty;
         }
 
         //   Add the result to working frameSequence
@@ -476,6 +483,10 @@ FrameSequence FrameSequenceParser::parse (const String& input,
         if (*error > kParseErrorLevelFatal)
         {
             return fs;
+        }
+        if (releaseSeq.size() == 0) {
+            // Release section is defined but content is empty
+            *error = kParseWarningRepeatSegmentEmpty;
         }
 
         //   Add the result to working frameSequence


### PR DESCRIPTION
Each section of Custom Envelope is supposed to  have a value, but it still works without it.
Although it works it's not proper, so a non-fatal message is added for section without value.