### PR TITLE
Vibratofix

### DIFF
--- a/Source/TonalVoice.cpp
+++ b/Source/TonalVoice.cpp
@@ -102,7 +102,7 @@ double TonalVoice::getVibratoPhase()
 
     float delay = * (settingRefs->vibratoDelay);
     float rate = * (settingRefs->vibratoRate);
-    rate = 1.1 - rate;
+    rate = 1.01 - rate;
 
     if ( sec < delay ) { return 0.0; }
 

--- a/Source/TonalVoice.cpp
+++ b/Source/TonalVoice.cpp
@@ -102,6 +102,7 @@ double TonalVoice::getVibratoPhase()
 
     float delay = * (settingRefs->vibratoDelay);
     float rate = * (settingRefs->vibratoRate);
+    rate = 1.1 - rate;
 
     if ( sec < delay ) { return 0.0; }
 


### PR DESCRIPTION
Fix so that slider goes up in frequency as rate is increased. Range (.01 to 1) is unaffected; should just flip the response.