### PR TITLE
[BUGFIX] Fixed custom envelope main section empty error

### DIFF
--- a/Source/EnvelopeParserTest.h
+++ b/Source/EnvelopeParserTest.h
@@ -328,7 +328,6 @@ public:
         expect(result30.valueAt(1) == 2);
         expect(result30.loopStartIndex == 0);
         expect(result30.releaseSequenceStartIndex == 1);
-        expect(error = kParseWarningPreRepeatSegmentEmpty);
 
         beginTest ("Empty segment warning(in-repeat)");
         error = kParseErrorNone;

--- a/Source/FrameSequenceParseErrors.cpp
+++ b/Source/FrameSequenceParseErrors.cpp
@@ -14,16 +14,16 @@ String getParseErrorString (ParseError err, int minValue, int maxValue)
 {
     switch (err)
     {
-        case kParseWarningPreRepeatSegmentEmpty:
-            return TRANS ("Main body of the sequence is empty");
-            break;
-
         case kParseWarningRepeatSegmentEmpty:
             return TRANS ("Repeat section is empty");
             break;
 
         case kParseWarningReleaseSegmentEmpty:
             return TRANS ("Release section is empty");
+            break;
+
+        case kParseErrorPreReleaseSegmentEmpty:
+            return TRANS ("Main body of the sequence is empty");
             break;
 
         case kParseErrorDuplicatedReleaseDelimiter:

--- a/Source/FrameSequenceParseErrors.h
+++ b/Source/FrameSequenceParseErrors.h
@@ -15,10 +15,10 @@ enum ParseError
 {
     kParseErrorNone = 0,
     kParseErrorLevelWarning,
-    kParseWarningPreRepeatSegmentEmpty,
     kParseWarningRepeatSegmentEmpty,
     kParseWarningReleaseSegmentEmpty,
     kParseErrorLevelFatal,
+    kParseErrorPreReleaseSegmentEmpty,
     kParseErrorDuplicatedReleaseDelimiter,
     kParseErrorDuplicatedOpenBracket,
     kParseErrorDuplicatedCloseBracket,

--- a/Source/FrameSequenceParser.cpp
+++ b/Source/FrameSequenceParser.cpp
@@ -438,9 +438,6 @@ FrameSequence FrameSequenceParser::parse (const String& input,
     {
         return fs;
     }
-    if (sequence.size() == 0) {
-        *error = kParseWarningPreRepeatSegmentEmpty;
-    }
 
     fs.sequence = sequence;
     fs.sequence.reserve (1000);
@@ -469,6 +466,10 @@ FrameSequence FrameSequenceParser::parse (const String& input,
 
         //   Set repeatEndIndex according to current working frameSequence length
         fs.releaseSequenceStartIndex = (int)fs.sequence.size();
+    }
+    
+    if (fs.sequence.size() == 0) {
+        *error = kParseErrorPreReleaseSegmentEmpty;
     }
 
     if (hasRelease)  // If release exists:


### PR DESCRIPTION
Should be error if both of pre-repeat and repeat sections are empty.
