### PR TITLE
Re: Added Tools in builder_linux for Building with JUCE CMake API

### DIFF
--- a/builder_linux/.gitignore
+++ b/builder_linux/.gitignore
@@ -1,0 +1,5 @@
+# Temporary folder used on builder_linux.sh
+/modules
+
+# Temporary folder used on CMakeLists.txt
+/build

--- a/builder_linux/CMakeLists.txt
+++ b/builder_linux/CMakeLists.txt
@@ -1,0 +1,126 @@
+cmake_minimum_required(VERSION 3.15)
+set(PLUGIN_NAME "Magical8bitPlug2")
+string(TOLOWER ${PLUGIN_NAME} PLUGIN_NAME_LOWERCASE)
+project(${PLUGIN_NAME}_project VERSION 1.1.0)
+
+option(PLUGIN_VST3 "Build VST3 Plugin" OFF)
+option(PLUGIN_LV2 "Build LADSPA Version 2 Plugin" OFF)
+
+#find_package(JUCE CONFIG REQUIRED) # You need to install compiled JUCE framework to your system.
+# Or,
+add_subdirectory(modules/JUCE) # JUCE framework on a subdirectory.
+
+set(PLUGIN_FORMATS Standalone)
+if(PLUGIN_VST3)
+  list(APPEND PLUGIN_FORMATS VST3)
+endif()
+if(PLUGIN_LV2)
+  list(APPEND PLUGIN_FORMATS LV2)
+endif()
+
+message(STATUS "JUCE Formats: ${PLUGIN_FORMATS}")
+
+juce_add_plugin(${PLUGIN_NAME}
+  PLUGIN_NAME ${PLUGIN_NAME}
+  PRODUCT_NAME ${PLUGIN_NAME_LOWERCASE}
+  VERSION ${CMAKE_PROJECT_VERSION}
+  BUNDLE_ID "com.ymck.magical8bitPlug2Juce"
+  ICON_SMALL "../Resources/icon-256.png"
+  ICON_LARGE "../Resources/icon-512.png"
+  COMPANY_NAME "Ymck"
+  COMPANY_WEBSITE "http://ymck.net"
+  COMPANY_EMAIL "info@ymck.net"
+  IS_SYNTH TRUE
+  NEEDS_MIDI_INPUT TRUE
+  NEEDS_MIDI_OUTPUT FALSE
+  IS_MIDI_EFFECT FALSE
+  PLUGIN_MANUFACTURER_CODE "Ymck"
+  PLUGIN_CODE "synj"
+  FORMATS ${PLUGIN_FORMATS}
+  LV2_URI "http://ymck.net"
+  DESCRIPTION "8bit sound generator 2nd ver. by YMCK"
+)
+
+# Generate JuceHeader.h
+juce_generate_juce_header(${PLUGIN_NAME})
+
+target_compile_definitions(${PLUGIN_NAME}
+  PUBLIC
+    JUCE_JACK=1
+    JUCE_WEB_BROWSER=0
+    JUCE_USE_CURL=0
+    JUCE_DISPLAY_SPLASH_SCREEN=1
+    JUCE_USE_DARK_SPLASH_SCREEN=0
+    JUCE_REPORT_APP_USAGE=0
+    JUCE_VST3_CAN_REPLACE_VST2=0
+    JUCE_STRICT_REFCOUNTEDPOINTER=1
+)
+
+target_sources(${PLUGIN_NAME}
+  PRIVATE
+    ../Source/CheckBoxComponent.cpp
+    ../Source/ChoiceComponent.cpp
+    ../Source/CustomEnvelopeComponent.cpp
+    ../Source/SliderComponent.cpp
+    ../Source/AdvancedParamsComponent.cpp
+    ../Source/BasicParamsComponent.cpp
+    ../Source/BendParamsComponent.cpp
+    ../Source/EnvelopeParamsComponent.cpp
+    ../Source/MonophonicComponent.cpp
+    ../Source/NoiseParamsComponent.cpp
+    ../Source/PulseParamsComponent.cpp
+    ../Source/SweepParamsComponent.cpp
+    ../Source/VibratoParamsComponent.cpp
+    ../Source/CustomSynth.cpp
+    ../Source/FrameSequenceParseErrors.cpp
+    ../Source/FrameSequenceParser.cpp
+    ../Source/ColorScheme.cpp
+    ../Source/BaseVoice.cpp
+    ../Source/NoiseVoice.cpp
+    ../Source/TriangleVoice.cpp
+    ../Source/PulseVoice.cpp
+    ../Source/TonalVoice.cpp
+    ../Source/Settings.cpp
+    ../Source/Voices.cpp
+    ../Source/PluginProcessor.cpp
+    ../Source/PluginEditor.cpp
+)
+
+juce_add_binary_data(${PLUGIN_NAME}_images
+  SOURCES
+    ../Resources/icon-256.png
+    ../Resources/icon-512.png
+)
+
+set_target_properties(${PLUGIN_NAME}_images
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE TRUE
+)
+
+# JUCE Modules and Binary Data
+target_link_libraries(${PLUGIN_NAME}
+  PRIVATE
+    juce::juce_audio_basics
+    juce::juce_audio_devices
+    juce::juce_audio_formats
+    juce::juce_audio_plugin_client
+    juce::juce_audio_processors
+    juce::juce_audio_utils
+    juce::juce_core
+    juce::juce_cryptography
+    juce::juce_data_structures
+    juce::juce_events
+    juce::juce_graphics
+    juce::juce_gui_basics
+    juce::juce_gui_extra
+    juce::juce_opengl
+    ${PLUGIN_NAME}_images
+)
+
+# Recommended Flags
+target_link_libraries(${PLUGIN_NAME}
+  PUBLIC
+    juce::juce_recommended_warning_flags
+    juce::juce_recommended_config_flags
+    juce::juce_recommended_lto_flags
+)

--- a/builder_linux/README.md
+++ b/builder_linux/README.md
@@ -1,0 +1,55 @@
+# Tools for Building and Installing Programs Based on JUCE Framework in Linux Using JUCE CMake API
+
+* Since JUCE version 6.0.0, JUCE CMake API became available. [Read its official documentation about JUCE CMake API.](https://github.com/juce-framework/JUCE/blob/master/docs/CMake%20API.md)
+
+* JUCE CMake API is useful to build executables and plugins in Linux, giving flexibility on adding features and optional building.
+
+**Dependancies**
+
+* Primary Dependencies for JUCE framework in Linux
+  1. [Read its official documentation of dependencies in Linux](https://github.com/juce-framework/JUCE/blob/master/docs/Linux%20Dependencies.md)
+
+* Additional Dependencies
+  1. "git" - To Clone JUCE SDK
+  2. "clang" - Portable Compiler over Processors and Architectures: I confirmed that version 11.0.1-2 in Raspberry Pi OS on Raspberry Pi 3B can compile a project with JUCE framework. GNU C/C++ compiler is the default compiler for Linux. However, the GNU compiler for arm-none-linux-gnueabi (version 10.2.1-6) needs to explicitly link libatomic which is implicitly linked in compilers for other processors. This issue may occur errors on compiling.
+  3. "cmake" - Build Environment: Version 3.15 and Above
+  4. "lv2-dev" - Development Tools for LV2 Plugin
+
+**builder_linux.sh**
+
+* This Bash script downloads JUCE framework and builds a standalone executable, a VST3 plugin, and a LV2 plugin.
+  * Example to Build All: `./builder_linux.sh vst3 lv2`
+  * A standalone executable is build without any argument.
+  * If you select to build a LV2 plugin, the JUCE framework is downloaded from [the fork of the LV2 porting project](https://github.com/lv2-porting-project/JUCE/tree/lv2).
+  * This script executes CMake with CMakeLists.txt in this folder. LLVM Clang is assigned as the C/C++ compiler.
+  * Written by Kenta Ishii (JimmyKenMerchant.com) in January 2022
+
+* Arguments (Orderless):
+  1. "vst3" - Build VST3 Plugin
+  2. "lv2" - Build LV2 Plugin
+  3. "debug" - Build for Debugging
+  4. "newjuce" - Reinstall Juce Framework: This's useful when you've already built without a LV2 plugin, but you want to build again for a LV2 plugin.
+
+**installer_linux.sh**
+
+* This Bash script helps to install an executable and plugins to your Linux system.
+  * Example to Install All: `./installer_linux.sh standalone vst3 lv2`
+  * Example to Uninstall Standalone: `./installer_linux.sh standalone uninstall`
+  * This script needs the root privilege.
+  * '/usr/local' is the prefix to destinations. Change the value of PREFIX_PATH in this script if you want to install an executable and plugins into other destinations.
+  * Written by Kenta Ishii (JimmyKenMerchant.com) in January 2022
+
+* Arguments (Orderless):
+  1. "standalone" - Install/Uninstall Standalone Executable to PREFIX_PATH/bin
+  2. "icons" - Install/Uninstall Small, Big, and Scalable Icons to PREFIX_PATH/share/icons/hicolor/ICON_SIZExICON_SIZE(or 'scalable')/apps: A .desktop (Desktop Entry) file is also installed to PREFIX_PATH/share/applications for linking icons to the standalone executable. Installed icons will appear after restarting you system.
+  3. "vst3" - Install/Uninstall VST3 Plugin Package to PREFIX_PATH/lib/vst3
+  4. "lv2" - Install/Uninstall LV2 Plugin Package to PREFIX_PATH/lib/lv2
+  5. "uninstall" - Set Uninstall Mode
+
+**History**
+
+* February 26, 2022: Added GPLv3 License to "builder_linux.sh" and "installer_linux.sh".
+* February 23, 2022: Modified "installer_linux.sh" about installing icons with imcomplete set of sizes.
+* February 5, 2022: Added the "icons" arguments to "installer_linux.sh". Installing with lowercase letters.
+* January 30, 2022: Added the "debug" and "newjuce" arguments to "builder_linux.sh".
+* January 29, 2022: Published "builder_linux.sh", "installer_linux.sh", and "README.md" for the first time.

--- a/builder_linux/builder_linux.sh
+++ b/builder_linux/builder_linux.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+##########################################################################
+# builder_linux.sh
+# Copyright (C) 2022 Kenta Ishii
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+##########################################################################
+# LLVM Clang is preferred for portability of projects, e.g., on ARM processors.
+# Read https://github.com/juce-framework/JUCE/blob/master/docs/Linux%20Dependencies.md
+# Additional Dependencies: lv2-dev clang
+PLUGINS=''
+REPO=''
+CONFIG='Release'
+# Search All Arguments
+if [[ $@ == *'newjuce'* ]]; then
+  if [ -e "modules/JUCE" ]; then
+    echo 'Deleting Existing JUCE Framework'
+    rm -r modules/JUCE
+  fi
+fi
+if [[ $@ == *'vst3'* ]]; then
+  echo 'Building VST3 Plugin'
+  PLUGINS+='-DPLUGIN_VST3=ON'
+fi
+if [[ $@ == *'lv2'* ]]; then
+  echo 'Building LV2 Plugin'
+  PLUGINS+=' -DPLUGIN_LV2=ON'
+  # Fork of LV2 Porting Project
+  REPO+='--branch lv2 https://github.com/lv2-porting-project/JUCE'
+else
+  # Official Repository
+  REPO+='https://github.com/juce-framework/JUCE'
+fi
+if [[ $@ == *'debug'* ]]; then
+  echo 'Building for Debugging'
+  CONFIG='Debug'
+fi
+echo 'Executing git clone '${REPO}
+if [ ! -d "modules" ]; then
+  mkdir modules
+fi
+git clone ${REPO} modules/JUCE
+cmake -Bbuild -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ${PLUGINS} .
+cmake --build build --config ${CONFIG}

--- a/builder_linux/installer_linux.sh
+++ b/builder_linux/installer_linux.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+##########################################################################
+# installer_linux.sh
+# Copyright (C) 2022 Kenta Ishii
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+##########################################################################
+PLUGIN_NAME='Magical8bitPlug2'
+PREFIX_PATH='/usr/local'
+ICON_PATH='../Resources'
+ICON_NAME='icon-'
+ICON_SMALL_SIZE=''
+ICON_BIG_SIZE='256'
+ICON_EXTENSION='png'
+ICON_EXTENSION_SCALABLE=''
+PLUGIN_NAME_LOWERCASE=$(echo ${PLUGIN_NAME} | tr '[:upper:]' '[:lower:]')
+if [[ $@ == *'uninstall'* ]]; then
+  if [[ $@ == *'standalone'* ]]; then
+    echo "${PLUGIN_NAME}: Uninstalling Standalone..."
+    rm ${PREFIX_PATH}/bin/${PLUGIN_NAME_LOWERCASE}
+  fi
+  if [[ $@ == *'icons'* ]]; then
+    if [[ ${ICON_SMALL_SIZE} != '' && ${ICON_EXTENSION} != '' ]]; then
+      echo "${PLUGIN_NAME}: Uninstalling ${ICON_SMALL_SIZE}x${ICON_SMALL_SIZE} .${ICON_EXTENSION} Icons..."
+      rm ${PREFIX_PATH}/share/icons/hicolor/${ICON_SMALL_SIZE}x${ICON_SMALL_SIZE}/apps/${PLUGIN_NAME_LOWERCASE}.${ICON_EXTENSION}
+    fi
+    if [[ ${ICON_BIG_SIZE} != '' && ${ICON_EXTENSION} != '' ]]; then
+      echo "${PLUGIN_NAME}: Uninstalling ${ICON_BIG_SIZE}x${ICON_BIG_SIZE} .${ICON_EXTENSION} Icons..."
+      rm ${PREFIX_PATH}/share/icons/hicolor/${ICON_BIG_SIZE}x${ICON_BIG_SIZE}/apps/${PLUGIN_NAME_LOWERCASE}.${ICON_EXTENSION}
+    fi
+    if [[ ${ICON_EXTENSION_SCALABLE} != '' ]]; then
+      echo "${PLUGIN_NAME}: Uninstalling Scalable .${ICON_EXTENSION_SCALABLE} Icons..."
+      rm ${PREFIX_PATH}/share/icons/hicolor/scalable/apps/${PLUGIN_NAME_LOWERCASE}.${ICON_EXTENSION_SCALABLE}
+    fi
+    echo "${PLUGIN_NAME}: Uninstalling ${PLUGIN_NAME_LOWERCASE}.desktop..."
+    rm ${PREFIX_PATH}/share/applications/${PLUGIN_NAME_LOWERCASE}.desktop
+  fi
+  if [[ $@ == *'vst3'* ]]; then
+    echo "${PLUGIN_NAME}: Uninstalling VST3 Plugin..."
+    rm -r ${PREFIX_PATH}/lib/vst3/${PLUGIN_NAME_LOWERCASE}.vst3
+  fi
+  if [[ $@ == *'lv2'* ]]; then
+    echo "${PLUGIN_NAME}: Uninstalling LV2 Plugin..."
+    rm -r ${PREFIX_PATH}/lib/lv2/${PLUGIN_NAME_LOWERCASE}.lv2
+  fi
+else
+  if [[ $@ == *'standalone'* ]]; then
+    echo "${PLUGIN_NAME}: Installing Standalone..."
+    cp build/${PLUGIN_NAME}_artefacts/Standalone/${PLUGIN_NAME_LOWERCASE} ${PREFIX_PATH}/bin/
+  fi
+  if [[ $@ == *'icons'* ]]; then
+    if [[ ${ICON_SMALL_SIZE} != '' && ${ICON_EXTENSION} != '' ]]; then
+      echo "${PLUGIN_NAME}: Installing ${ICON_SMALL_SIZE}x${ICON_SMALL_SIZE} .${ICON_EXTENSION} Icons..."
+      cp ${ICON_PATH}/${ICON_NAME}${ICON_SMALL_SIZE}.${ICON_EXTENSION} ${PREFIX_PATH}/share/icons/hicolor/${ICON_SMALL_SIZE}x${ICON_SMALL_SIZE}/apps/${PLUGIN_NAME_LOWERCASE}.${ICON_EXTENSION}
+    fi
+    if [[ ${ICON_BIG_SIZE} != '' && ${ICON_EXTENSION} != '' ]]; then
+      echo "${PLUGIN_NAME}: Installing ${ICON_BIG_SIZE}x${ICON_BIG_SIZE} .${ICON_EXTENSION} Icons..."
+      cp ${ICON_PATH}/${ICON_NAME}${ICON_BIG_SIZE}.${ICON_EXTENSION} ${PREFIX_PATH}/share/icons/hicolor/${ICON_BIG_SIZE}x${ICON_BIG_SIZE}/apps/${PLUGIN_NAME_LOWERCASE}.${ICON_EXTENSION}
+    fi
+    if [[ ${ICON_EXTENSION_SCALABLE} != '' ]]; then
+      echo "${PLUGIN_NAME}: Installing Scalable .${ICON_EXTENSION_SCALABLE} Icons..."
+      cp ${ICON_PATH}/${ICON_NAME}.${ICON_EXTENSION_SCALABLE} ${PREFIX_PATH}/share/icons/hicolor/scalable/apps/${PLUGIN_NAME_LOWERCASE}.${ICON_EXTENSION_SCALABLE}
+    fi
+    echo "${PLUGIN_NAME}: Installing ${PLUGIN_NAME_LOWERCASE}.desktop..."
+    cp ${PLUGIN_NAME_LOWERCASE}.desktop ${PREFIX_PATH}/share/applications
+  fi
+  if [[ $@ == *'vst3'* ]]; then
+    echo "${PLUGIN_NAME}: Installing VST3 Plugin..."
+    if [ ! -d "${PREFIX_PATH}/lib/vst3" ]; then
+      mkdir ${PREFIX_PATH}/lib/vst3
+    fi
+    cp -r build/${PLUGIN_NAME}_artefacts/VST3/${PLUGIN_NAME_LOWERCASE}.vst3 ${PREFIX_PATH}/lib/vst3/
+  fi
+  if [[ $@ == *'lv2'* ]]; then
+    echo "${PLUGIN_NAME}: Installing LV2 Plugin..."
+    if [ ! -d "${PREFIX_PATH}/lib/lv2" ]; then
+      mkdir ${PREFIX_PATH}/lib/lv2
+    fi
+    cp -r build/${PLUGIN_NAME}_artefacts/LV2/${PLUGIN_NAME_LOWERCASE}.lv2 ${PREFIX_PATH}/lib/lv2/
+  fi
+fi

--- a/builder_linux/magical8bitplug2.desktop
+++ b/builder_linux/magical8bitplug2.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Magical8bitPlug2
+GenericName=Audio Plugin
+GenericName[ja]=オーディオプラグイン
+Comment=Standalone Audio Plugin
+Comment[ja]=スタンドアローン型オーディオプラグイン
+Exec=magical8bitplug2
+Icon=magical8bitplug2
+Terminal=false
+Type=Application
+Categories=AudioVideo;Audio;
+MimeType=application/x-magical8bitplug2-project;


### PR DESCRIPTION
Reissued PR to fix the merge target from release/1.1.0 to develop.
original: https://github.com/yokemura/Magical8bitPlug2/pull/35